### PR TITLE
Update bb navbar item functionality and styling

### DIFF
--- a/cypress/component/bbnavbar_item.cy.tsx
+++ b/cypress/component/bbnavbar_item.cy.tsx
@@ -25,9 +25,15 @@ describe('BBNavbarItem Component Tests', () => {
     });
 
     it('renders with dropdown children', () => {
-      const children = [<BBNavbarItem key="1" title="Sub Item 1" href="/sub1" />, <BBNavbarItem key="2" title="Sub Item 2" href="/sub2" />];
-      cy.mount(<BBNavbarItem {...defaultProps} children={children} />);
+      const dropdownChildren = [<BBNavbarItem key="1" title="Sub Item 1" href="/sub1" />, <BBNavbarItem key="2" title="Sub Item 2" href="/sub2" />];
+      cy.mount(<BBNavbarItem {...defaultProps} dropdownChildren={dropdownChildren} />);
       cy.get('li').should('exist'); // Dropdown container exists
+    });
+
+    it('renders with children component instead of title', () => {
+      const buttonComponent = <button>Custom Button</button>;
+      cy.mount(<BBNavbarItem href="/test" children={buttonComponent} />);
+      cy.contains('Custom Button').should('exist');
     });
   });
 
@@ -60,8 +66,8 @@ describe('BBNavbarItem Component Tests', () => {
 
   describe('Dropdown Behavior', () => {
     it('shows dropdown content when hovering over item with children', () => {
-      const children = [<BBNavbarItem key="1" title="Sub Item" href="/sub" />];
-      cy.mount(<BBNavbarItem {...defaultProps} children={children} />);
+      const dropdownChildren = [<BBNavbarItem key="1" title="Sub Item" href="/sub" />];
+      cy.mount(<BBNavbarItem {...defaultProps} dropdownChildren={dropdownChildren} />);
       cy.get('li').first().trigger('mouseenter');
       cy.contains('Sub Item').should('exist');
     });

--- a/src/bbnavbar_item/index.tsx
+++ b/src/bbnavbar_item/index.tsx
@@ -40,8 +40,9 @@ const getClassColorBorder = (colorBorder: TBBNavbarItemColorBorder): string => {
 /**
  * PROPS
  *
- * @param {string} title - Title to use for item.
- * @param {React.ReactElement=} children - Children to render.
+ * @param {string=} title - Title to use for item (optional if children provided).
+ * @param {React.ReactNode=} children - Children to render instead of title text, or dropdown children.
+ * @param {React.ReactElement[]=} dropdownChildren - Dropdown children to render.
  * @param {string} href - Href to use for item.
  * @param {string=} className - Any class name to add.
  * @param {TBBNavbarItemColorBorder=} colorBorder - Color of the border.
@@ -49,8 +50,9 @@ const getClassColorBorder = (colorBorder: TBBNavbarItemColorBorder): string => {
  * @param {string[]=} activePaths - Paths to consider as active. Consider this an override to the current path. Do not include the base path.
  */
 export interface IPropsBBNavbarItem {
-  title: string;
-  children?: React.ReactElement[];
+  title?: string;
+  children?: React.ReactNode;
+  dropdownChildren?: React.ReactElement[];
   href: string;
   className?: string;
   colorBorder?: TBBNavbarItemColorBorder;
@@ -62,7 +64,7 @@ export interface IPropsBBNavbarItem {
  * BBNAVBAR ITEM
  */
 export default function BBNavbarItem(Props: IPropsBBNavbarItem): React.ReactElement {
-  const { title, href, className, children, colorBorder = 'default', noBorder = false, activePaths } = Props;
+  const { title, href, className, children, dropdownChildren, colorBorder = 'default', noBorder = false, activePaths } = Props;
   const [isActiveInDropdown, setIsActiveInDropdown] = useState(false);
   const [currentPath, setCurrentPath] = useState<string>('');
 
@@ -79,7 +81,7 @@ export default function BBNavbarItem(Props: IPropsBBNavbarItem): React.ReactElem
 
   useEffect(() => {
     let found = false;
-    children?.forEach((child) => {
+    dropdownChildren?.forEach((child: React.ReactElement) => {
       if (removeSlashes(currentPath) === removeSlashes(child.props.href)) {
         found = true;
       }
@@ -95,20 +97,20 @@ export default function BBNavbarItem(Props: IPropsBBNavbarItem): React.ReactElem
     }
 
     setIsActiveInDropdown(found);
-  }, [children, currentPath, activePaths]);
+  }, [dropdownChildren, currentPath, activePaths]);
 
   const urlMatch = !!currentPath.length && !!href.length && removeSlashes(currentPath) === removeSlashes(href);
   const isActive = urlMatch || isActiveInDropdown;
 
   return (
     <li
-      id={`nav-item-${title.toLowerCase()}`}
+      id={`nav-item-${title?.toLowerCase() || 'item'}`}
       className={classnames(
         styles.navbarItemBase,
         styles.dropdownContainer,
         noBorder ? styles.noBorder : '',
         getClassColorBorder(colorBorder),
-        { [styles.active]: isActive, [styles.hasChildren]: !!children?.length },
+        { [styles.active]: isActive, [styles.hasChildren]: !!dropdownChildren?.length },
         className
       )}
     >
@@ -120,11 +122,11 @@ export default function BBNavbarItem(Props: IPropsBBNavbarItem): React.ReactElem
             // hover is handled by this BBNavbarItem component
             hover={false}
           >
-            {title}
+            {children || title}
           </BBLink>
-          {!!children?.length && <IoMdArrowDropdown size={30} className={styles.iconDropdown} />}
+          {!!dropdownChildren?.length && <IoMdArrowDropdown size={30} className={styles.iconDropdown} />}
         </div>
-        {!!children?.length && <ul className={styles.dropdownContent}>{children}</ul>}
+        {!!dropdownChildren?.length && <ul className={styles.dropdownContent}>{dropdownChildren}</ul>}
       </div>
     </li>
   );

--- a/src/bbnavbar_item/styles.module.scss
+++ b/src/bbnavbar_item/styles.module.scss
@@ -38,7 +38,7 @@ $navbar-item-bg-color-active: var(--navbar-item-bg-color-active, $bg-dark-color)
 $navbar-item-bg-color-hover: var(--navbar-item-bg-color-hover, $bg-color);
 
 // set min width
-$navbar-item-min-width: var(--navbar-item-min-width, unset);
+$navbar-item-min-width: var(--navbar-item-min-width, 6rem);
 
 .active {
   background-color: $navbar-item-text-color;
@@ -56,11 +56,16 @@ $navbar-item-min-width: var(--navbar-item-min-width, unset);
   margin: 0 0.15rem;
   border-radius: $border-radius;
   background-color: $navbar-item-color;
+  white-space: nowrap;
 
   a {
     text-align: center;
     text-decoration: none;
     width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
     * {
       padding: $navbar-item-padding;
     }
@@ -100,12 +105,13 @@ $navbar-item-min-width: var(--navbar-item-min-width, unset);
 
 // TODO find a better selector than these two
 // this is for the text
-.navbarItemBase:hover > div > div > a > * {
+.navbarItemBase:hover>div>div>a>* {
   // need the !important to override the default color / active color
   color: $navbar-item-text-color-hover !important;
 }
+
 // this is for the icon
-.navbarItemBase:hover > div > div > .iconDropdown {
+.navbarItemBase:hover>div>div>.iconDropdown {
   // need the !important to override the default color / active color
   color: $navbar-item-text-color-hover !important;
 }


### PR DESCRIPTION
```
# Pull Request Template

## Description

This PR implements several enhancements to the `BBNavbarItem` component, addressing the following:

1.  **Component as Children**: Allows `BBNavbarItem` to accept any `React.ReactNode` as its `children` prop, enabling more flexible content (e.g., buttons, icons) instead of just strings. The `title` prop is now optional.
2.  **Dedicated Dropdown Children**: Introduced a new `dropdownChildren` prop to explicitly define content for dropdown menus, separating it from the main item's children.
3.  **Improved Styling**:
    *   Adjusted the default `min-width` to `6rem` for better alignment.
    *   Implemented flexbox centering to correctly align text within the item.
    *   Added `white-space: nowrap` to ensure item content remains on a single line.

These changes enhance the flexibility and visual consistency of the `BBNavbarItem`.

Fixes # (issue) - *No specific issue number provided, addresses requested enhancements.*

## Type of change

-   [x] Bug fix (non-breaking change which fixes an issue - styling/alignment)
-   [x] New feature (non-breaking change which adds functionality - components as children, dropdownChildren prop)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] This change requires a documentation update

## How Has This Been Tested?

The following tests were performed to verify the changes:

-   [x] **Cypress Component Tests**: Updated and ran existing Cypress component tests for `BBNavbarItem`.
    *   Verified rendering with `dropdownChildren`.
    *   Added a new test case to confirm rendering of a custom component (e.g., `<button>`) passed as `children`.
-   [x] **TypeScript Linting**: Ran `npm run lint` to ensure no TypeScript compilation issues or linting errors were introduced.

**Test Configuration**:
*   N/A

## Checklist:

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have made corresponding changes to the documentation
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [ ] Any dependent changes have been merged and published in downstream modules
-   [x] MY CODE PASSES CI (unless you have a really, really good reason)
```