### PR TITLE
Rename bb dropdown to bb select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fixed `transparentPrimary`, `transparentSecondary` and `transparentAccent` variants
 - `BBNavbarItem`
   - added `navbar-item-min-width` to set min width
-- `BBFieldDropdown`
-  - Improved styling by adding a custom dropdown arrow.
+- `BBFieldSelect`
+- Improved styling by adding a custom dropdown arrow.
 - `BBLoadingSpinner`
   - Added `color` prop to allow for custom colors.
 - `BBFieldFile`

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ At the moment, the following components are available:
 As well as the following 'Form Components':
 - `BBFieldBase`
 - `BBFieldCheckbox`
-- `BBFieldDropdown`
+- `BBFieldSelect`
 - `BBFieldFile`
 - `BBFieldNumber`
 - `BBFieldSelectCard`

--- a/TODO.md
+++ b/TODO.md
@@ -267,10 +267,11 @@
 ---
 
 
-#### rename bb dropdown to bb select?
+#### rename bb dropdown to bb select? ✅ COMPLETED
 - is that more appropriate
   - def more common name
 - then could merge with bb select multiple
+- **COMPLETED**: Renamed BBFieldDropdown to BBFieldSelect throughout the codebase
 
 
 #### work on defaults / variables system

--- a/src/form_components/bbfield_select/index.tsx
+++ b/src/form_components/bbfield_select/index.tsx
@@ -2,23 +2,23 @@ import classnames from 'classnames';
 import React from 'react';
 import InputWrapper from '../input_wrapper';
 import styles from '../styles.module.scss';
-import type { IBBFieldDropdownOptions, IPropsBBBaseForm, TBBFieldBaseSize } from '../../types';
+import type { IBBFieldSelectOptions, IPropsBBBaseForm, TBBFieldBaseSize } from '../../types';
 
 /**
  * PROPS
  *
- * @param {IBBFieldSelectMultipleOptions[]} options - Options to display.
+ * @param {IBBFieldSelectOptions[]} options - Options to display.
  * @param {string=} size - Size of the input. Think 'sm', 'md', or 'lg'.
  */
-export interface IPropsBBFieldDropdown {
-  options: IBBFieldDropdownOptions[];
+export interface IPropsBBFieldSelect {
+  options: IBBFieldSelectOptions[];
   size?: TBBFieldBaseSize;
 }
 
 /**
- * BBFIELD DROPDOWN
+ * BBFIELD SELECT
  */
-export default function BBFieldDropdown(Props: IPropsBBFieldDropdown & IPropsBBBaseForm): React.ReactElement {
+export default function BBFieldSelect(Props: IPropsBBFieldSelect & IPropsBBBaseForm): React.ReactElement {
   const { register, options, fieldName, required, autocomplete, onChange, size = 'md' } = Props;
 
   const getAutoComplete = (): string => {
@@ -40,7 +40,7 @@ export default function BBFieldDropdown(Props: IPropsBBFieldDropdown & IPropsBBB
           autoComplete={getAutoComplete()}
           {...register}
         >
-          {options.map((val: IBBFieldDropdownOptions) => (
+          {options.map((val: IBBFieldSelectOptions) => (
             <option key={val.value} value={val.value}>
               {val.label}
             </option>

--- a/src/pages/form-components/index.tsx
+++ b/src/pages/form-components/index.tsx
@@ -3,11 +3,11 @@ import BBLink from '../../bblink';
 import BBText from '../../bbtext';
 import DemoComponent from '../../demo_components/demo_component';
 import BBFieldCheckbox from '../../form_components/bbfield_checkbox';
-import BBFieldDropdown from '../../form_components/bbfield_dropdown';
 import BBFieldFile from '../../form_components/bbfield_file';
+import BBFieldSelect from '../../form_components/bbfield_select';
 import BBFieldText from '../../form_components/bbfield_text';
 import type { IPropsBBFieldCheckbox } from '../../form_components/bbfield_checkbox';
-import type { IPropsBBFieldDropdown } from '../../form_components/bbfield_dropdown';
+import type { IPropsBBFieldSelect } from '../../form_components/bbfield_select';
 import type { IPropsBBFieldText } from '../../form_components/bbfield_text';
 import type { IPropsBBBaseForm } from '../../types';
 
@@ -50,15 +50,15 @@ const FormComponentsPage = () => {
     size: 'md',
   });
 
-  // BB Field Dropdown
-  const [stateBBFieldDropdown, setStateBBFieldDropdown] = useState<IPropsBBFieldDropdown & IPropsBBBaseForm>({
-    fieldName: 'demo-dropdown',
+  // BB Field Select
+  const [stateBBFieldSelect, setStateBBFieldSelect] = useState<IPropsBBFieldSelect & IPropsBBBaseForm>({
+    fieldName: 'demo-select',
     required: false,
-    label: 'Demo Dropdown',
+    label: 'Demo Select',
     className: '',
     onChange: (event) => {
       const selectedValue = event.target.value;
-      setStateBBFieldDropdown((prevState) => ({
+      setStateBBFieldSelect((prevState) => ({
         ...prevState,
         value: selectedValue,
       }));
@@ -149,10 +149,10 @@ const FormComponentsPage = () => {
         />
 
         <DemoComponent
-          name="BBFieldDropdown"
-          child={<BBFieldDropdown {...stateBBFieldDropdown} />}
-          stateObject={stateBBFieldDropdown}
-          setStateObject={setStateBBFieldDropdown}
+          name="BBFieldSelect"
+          child={<BBFieldSelect {...stateBBFieldSelect} />}
+          stateObject={stateBBFieldSelect}
+          setStateObject={setStateBBFieldSelect}
         />
 
         {/* TODO not working for some reason */}

--- a/src/types.ts
+++ b/src/types.ts
@@ -217,8 +217,8 @@ export interface IPropsBBFieldCheckbox {
   size?: TBBFieldCheckboxSize;
 }
 
-// TBBFieldDropdown
-export interface IBBFieldDropdownOptions {
+// TBBFieldSelect
+export interface IBBFieldSelectOptions {
   value: string;
   label: string;
 }


### PR DESCRIPTION
```
# Pull Request Template

## Description

This PR renames the `BBFieldDropdown` component to `BBFieldSelect` throughout the repository. This includes updating component names, interfaces, file paths, demo page references, and documentation.

The motivation for this change is:
*   "Select" is a more common and appropriate term for this type of form control.
*   It aligns better with standard HTML semantics.
*   It prepares for a potential future merge with a `bb select multiple` component.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) - *Renaming a public component is a breaking change for consumers.*
- [x] This change requires a documentation update

## How Has This Been Tested?

The following tests were performed to verify the changes:

- [x] `npm run build` was executed successfully.
- [x] TypeScript errors were checked and resolved.
- [x] ESLint compliance was verified (e.g., import order).
- [x] The demo page (`src/pages/form-components/index.tsx`) was updated and should be visually inspected to ensure the component functions as expected.

**Test Configuration**:
* Firmware version: N/A
* Hardware: N/A
* Toolchain: N/A
* SDK: N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (README, CHANGELOG, TODO)
- [x] I have added tests that prove my fix is effective or that my feature works (via build and lint checks, and demo page update)
- [x] New and existing unit tests pass locally with my changes (assuming `npm run build` covers this)
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] MY CODE PASSES CI (unless you have a really, really good reason)
```