### PR TITLE
Improve BBButton hover states: transitions, lift, and text contrast

### DIFF
--- a/src/bbbutton/styles.module.scss
+++ b/src/bbbutton/styles.module.scss
@@ -42,8 +42,24 @@ $button-base-border-radius: var(--button-base-border-radius, 4px);
 .base {
   padding: $button-base-padding;
   border-radius: var(--button-border-radius, 4px);
+  transition:
+    background-color 0.2s ease,
+    border-color 0.2s ease,
+    box-shadow 0.2s ease,
+    transform 0.2s ease;
+
   &:hover {
     cursor: pointer;
+  }
+
+  &:hover:not(.disabled) {
+    transform: translateY(-1px);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
+  }
+
+  &:active:not(.disabled) {
+    transform: translateY(0);
+    box-shadow: none;
   }
 }
 
@@ -204,11 +220,11 @@ $button-base-border-radius: var(--button-base-border-radius, 4px);
   color: $white;
 
   &:hover {
-    color: $grey-lightest;
+    color: $white;
     background-color: $primary-light-color;
 
     * {
-      color: $grey-lightest;
+      color: $white;
     }
   }
 
@@ -237,11 +253,11 @@ $button-base-border-radius: var(--button-base-border-radius, 4px);
   color: $white;
 
   &:hover {
-    color: $grey-lightest;
+    color: $white;
     background-color: $secondary-light-color;
 
     * {
-      color: $grey-lightest;
+      color: $white;
     }
   }
 
@@ -270,11 +286,11 @@ $button-base-border-radius: var(--button-base-border-radius, 4px);
   color: $white;
 
   &:hover {
-    color: $grey-lightest;
+    color: $white;
     background-color: $accent-light-color;
 
     * {
-      color: $grey-lightest;
+      color: $white;
     }
   }
 
@@ -303,11 +319,11 @@ $button-base-border-radius: var(--button-base-border-radius, 4px);
   color: $white;
 
   &:hover {
-    color: $grey-lightest;
+    color: $white;
     background-color: $danger-light-color;
 
     * {
-      color: $grey-lightest;
+      color: $white;
     }
   }
 
@@ -336,11 +352,11 @@ $button-base-border-radius: var(--button-base-border-radius, 4px);
   color: $white;
 
   &:hover {
-    color: $grey-lightest;
+    color: $white;
     background-color: $success-light-color;
 
     * {
-      color: $grey-lightest;
+      color: $white;
     }
   }
 
@@ -369,11 +385,11 @@ $button-base-border-radius: var(--button-base-border-radius, 4px);
   color: $white;
 
   &:hover {
-    color: $grey-lightest;
+    color: $white;
     background-color: $warning-light-color;
 
     * {
-      color: $grey-lightest;
+      color: $white;
     }
   }
 
@@ -402,11 +418,11 @@ $button-base-border-radius: var(--button-base-border-radius, 4px);
   color: $white;
 
   &:hover {
-    color: $grey-lightest;
+    color: $white;
     background-color: $info-light-color;
 
     * {
-      color: $grey-lightest;
+      color: $white;
     }
   }
 


### PR DESCRIPTION
## Summary
- Add smooth `transition` (0.2s ease) to `.base` for background-color, border-color, box-shadow, and transform
- Add subtle `translateY(-1px)` lift + box-shadow on hover, reset on active — gives buttons tactile feedback
- Fix text color on hover: keep white instead of fading to `$grey-lightest` across all 7 filled variants (primary, secondary, accent, danger, success, warning, info)

## Motivation
Current hover states have no transition (instant color snap), text degrades to grey (looks washed out / disabled), and there's no physical feedback. These are purely additive CSS changes — no prop changes, no markup changes, no breaking changes.

## Test plan
- [ ] Hover every filled variant — transition should be smooth, text stays white, button lifts slightly
- [ ] Click every filled variant — button should press back down (translateY resets)
- [ ] Verify disabled buttons are unaffected (no lift/shadow)
- [ ] Verify inverse and transparent variants are unaffected
- [ ] Run existing Cypress component tests