### PR TITLE
Add BBCode, BBQuote, BBLabel components + BBText weight prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,15 @@ At the moment, the following components are available:
 - `BBAlert`
 - `BBButton`
 - `BBCard`
+- `BBCode`
 - `BBCollapsible`
+- `BBLabel`
 - `BBLink`
 - `BBLoadingSpinner`
 - `BBModal`
 - `BBNavbar`
 - `BBNavbarItem`
+- `BBQuote`
 - `BBText`
 
 As well as the following 'Form Components':

--- a/TODO.md
+++ b/TODO.md
@@ -288,7 +288,12 @@
   - `--navbar-item-text-color-active` doesnt seem to exist and maybe should
 
 ### [2.4.0] - 2025-MM-DD
-- TODO
+- **`BBText` `weight` prop** - named font weights (`light` 300, `regular` 400, `medium` 500, `semibold` 600, `bold` 700). The existing `bold` boolean stays as a shorthand and is overridden by `weight` when both are set. Non-breaking.
+- **New `BBCode` component** - inline `<code>` (or block `<pre><code>` via `block`) for short code / CLI snippets. Renders monospace + a neutral theme-agnostic chrome and reuses the BBText size/color scale for the text.
+- **New `BBQuote` component** - semantic `<figure>`/`<blockquote>` pull quote with an optional `<figcaption><cite>` attribution, composed from BBText.
+- **New `BBLabel` component** - small uppercase, letter-spaced monospace eyebrow / kicker label, composed from BBText. Muted ink by default, overridable via `color`.
+- **`BBText` `xxxlarge` size fix** - desktop `xxxlarge` now uses `$text-size-xxxl` instead of `$text-size-xxl`, so it is actually larger than `xxlarge` (the two were the same size before). Mobile was already correct.
+- Cypress coverage + README entries for all of the above.
 
 -------------------------------------------------------
 

--- a/cypress/component/bbcode.cy.tsx
+++ b/cypress/component/bbcode.cy.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import BBCode from '../../src/bbcode';
+
+describe('BBCode Component Tests', () => {
+  beforeEach(() => {
+    cy.viewport(1280, 720);
+  });
+
+  describe('Basic Rendering', () => {
+    it('renders inline code by default', () => {
+      cy.mount(<BBCode>npm run build</BBCode>);
+      cy.get('code').should('contain.text', 'npm run build');
+      cy.get('pre').should('not.exist');
+    });
+
+    it('renders block code with pre when block is set', () => {
+      cy.mount(<BBCode block>$ docker compose up</BBCode>);
+      cy.get('pre').should('exist');
+      cy.get('pre code').should('contain.text', '$ docker compose up');
+    });
+
+    it('renders with custom className', () => {
+      cy.mount(<BBCode className="custom-code">x = 1</BBCode>);
+      cy.get('code.custom-code').should('exist');
+    });
+  });
+
+  describe('Styling', () => {
+    it('renders the text in a monospace font', () => {
+      cy.mount(<BBCode>mono()</BBCode>);
+      cy.get('code span')
+        .should('have.css', 'font-family')
+        .and('match', /mono|Consolas|Menlo|monospace/i);
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('handles special characters', () => {
+      cy.mount(<BBCode>{'preon trace SN-4471 | grep heat'}</BBCode>);
+      cy.get('code').should('contain.text', 'preon trace SN-4471 | grep heat');
+    });
+  });
+});

--- a/cypress/component/bblabel.cy.tsx
+++ b/cypress/component/bblabel.cy.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import BBLabel from '../../src/bblabel';
+
+describe('BBLabel Component Tests', () => {
+  beforeEach(() => {
+    cy.viewport(1280, 720);
+  });
+
+  describe('Basic Rendering', () => {
+    it('renders the label text in a span', () => {
+      cy.mount(<BBLabel>Pricing</BBLabel>);
+      cy.get('span').should('contain.text', 'Pricing');
+    });
+
+    it('renders as a span (inline label)', () => {
+      cy.mount(<BBLabel>why preon</BBLabel>);
+      cy.get('span').should('exist');
+      cy.get('span').should('contain.text', 'why preon');
+    });
+
+    it('renders with custom className', () => {
+      cy.mount(<BBLabel className="custom-label">Label</BBLabel>);
+      cy.get('.custom-label').should('exist');
+    });
+  });
+
+  describe('Color', () => {
+    it('renders with an explicit color', () => {
+      cy.mount(<BBLabel color="primary">Tag</BBLabel>);
+      cy.get('span').should('contain.text', 'Tag');
+    });
+  });
+
+  describe('Styling', () => {
+    it('renders the text in a monospace font', () => {
+      cy.mount(<BBLabel>mono</BBLabel>);
+      cy.get('span')
+        .should('have.css', 'font-family')
+        .and('match', /mono|monospace|Consolas|Menlo/i);
+    });
+  });
+});

--- a/cypress/component/bbquote.cy.tsx
+++ b/cypress/component/bbquote.cy.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import BBQuote from '../../src/bbquote';
+
+describe('BBQuote Component Tests', () => {
+  beforeEach(() => {
+    cy.viewport(1280, 720);
+  });
+
+  describe('Basic Rendering', () => {
+    it('renders the quote body inside figure/blockquote', () => {
+      cy.mount(<BBQuote>We said we have traceability.</BBQuote>);
+      cy.get('figure blockquote').should('contain.text', 'We said we have traceability.');
+    });
+
+    it('renders attribution inside figcaption/cite when cite is provided', () => {
+      cy.mount(<BBQuote cite="Quality lead, tier-2 aero shop">Quote text</BBQuote>);
+      cy.get('figure figcaption cite').should('contain.text', 'Quality lead, tier-2 aero shop');
+    });
+
+    it('omits figcaption when no cite is provided', () => {
+      cy.mount(<BBQuote>Just a quote</BBQuote>);
+      cy.get('figcaption').should('not.exist');
+    });
+
+    it('applies custom className to the figure', () => {
+      cy.mount(<BBQuote className="custom-quote">Quote</BBQuote>);
+      cy.get('figure.custom-quote').should('exist');
+    });
+  });
+
+  describe('Edge Cases', () => {
+    it('renders JSX cite content', () => {
+      cy.mount(
+        <BBQuote cite={<span data-testid="cite-jsx">Scott</span>}>Quote</BBQuote>
+      );
+      cy.get('[data-testid="cite-jsx"]').should('exist');
+    });
+  });
+});

--- a/cypress/component/bbtext.cy.tsx
+++ b/cypress/component/bbtext.cy.tsx
@@ -107,6 +107,40 @@ describe('BBText Component Tests', () => {
     });
   });
 
+  describe('Font Weights', () => {
+    const weights: Array<IPropsBBText['weight']> = [
+      'light',
+      'regular',
+      'medium',
+      'semibold',
+      'bold',
+    ];
+
+    weights.forEach((weight) => {
+      if (weight) {
+        it(`renders with weight="${weight}"`, () => {
+          cy.mount(
+            <BBText weight={weight} asSpan>
+              Weighted text
+            </BBText>
+          );
+          cy.get('span').should('exist');
+          cy.get('span').should('contain.text', 'Weighted text');
+        });
+      }
+    });
+
+    it('renders with both weight and bold set', () => {
+      cy.mount(
+        <BBText weight="medium" bold asSpan>
+          Precedence text
+        </BBText>
+      );
+      cy.get('span').should('exist');
+      cy.get('span').should('contain.text', 'Precedence text');
+    });
+  });
+
   describe('Content Rendering', () => {
     it('renders text content', () => {
       cy.mount(<BBText>Simple text content</BBText>);

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,8 @@
         "sass-loader": "16.0.5",
         "style-loader": "4.0.0",
         "ts-node": "10.9.2",
-        "typescript": "5.3.3"
+        "typescript": "5.3.3",
+        "webpack": "5.102.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3288,7 +3289,6 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -3300,7 +3300,6 @@
       "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint": "*",
         "@types/estree": "*"
@@ -3311,8 +3310,7 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/express": {
       "version": "4.17.23",
@@ -4126,7 +4124,6 @@
       "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/helper-numbers": "1.13.2",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
@@ -4137,24 +4134,21 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
       "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-api-error": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
       "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-buffer": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
       "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-numbers": {
       "version": "1.13.2",
@@ -4162,7 +4156,6 @@
       "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/floating-point-hex-parser": "1.13.2",
         "@webassemblyjs/helper-api-error": "1.13.2",
@@ -4174,8 +4167,7 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
       "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
       "version": "1.14.1",
@@ -4183,7 +4175,6 @@
       "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -4197,7 +4188,6 @@
       "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
       }
@@ -4208,7 +4198,6 @@
       "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@xtuc/long": "4.2.2"
       }
@@ -4218,8 +4207,7 @@
       "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
       "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/wasm-edit": {
       "version": "1.14.1",
@@ -4227,7 +4215,6 @@
       "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -4245,7 +4232,6 @@
       "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
@@ -4260,7 +4246,6 @@
       "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -4274,7 +4259,6 @@
       "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-api-error": "1.13.2",
@@ -4290,7 +4274,6 @@
       "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
@@ -4301,16 +4284,14 @@
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
       "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true,
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -4354,7 +4335,6 @@
       "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
       "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       },
@@ -5608,7 +5588,6 @@
       "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.0"
       }
@@ -6671,7 +6650,6 @@
       "integrity": "sha512-6Jw4sE1maoRJo3q8MsSIn2onJFbLTOjY9hlx4DZXmOKvLRd1Ok2kXmAGXaafL2+ijsJZ1ClYbl/pmqr9+k4iUQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -6686,7 +6664,6 @@
       "integrity": "sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -6844,8 +6821,7 @@
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -7806,7 +7782,6 @@
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -8612,8 +8587,7 @@
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true,
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/global-dirs": {
       "version": "3.0.1",
@@ -10247,7 +10221,6 @@
       "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "merge-stream": "^2.0.0",
@@ -10263,7 +10236,6 @@
       "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -10334,8 +10306,7 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/json-schema": {
       "version": "0.4.0",
@@ -10550,7 +10521,6 @@
       "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.11.5"
       }
@@ -12277,7 +12247,6 @@
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
       }
@@ -13104,7 +13073,6 @@
       "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "randombytes": "^2.1.0"
       }
@@ -13968,7 +13936,6 @@
       "integrity": "sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
@@ -14003,8 +13970,7 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/terser-webpack-plugin/node_modules/terser": {
       "version": "5.43.1",
@@ -14012,7 +13978,6 @@
       "integrity": "sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.14.0",
@@ -14819,7 +14784,6 @@
       "integrity": "sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -14843,7 +14807,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.102.0.tgz",
       "integrity": "sha512-hUtqAR3ZLVEYDEABdBioQCIqSoguHbFn1K7WlPPWSuXmx0031BD73PSE35jKyftdSh4YLDoQNgK4pqBt5Q82MA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -15106,7 +15069,6 @@
       "integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       }
@@ -15117,7 +15079,6 @@
       "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -15132,7 +15093,6 @@
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -15142,7 +15102,6 @@
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
       "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       },

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "sass-loader": "16.0.5",
     "style-loader": "4.0.0",
     "ts-node": "10.9.2",
-    "typescript": "5.3.3"
+    "typescript": "5.3.3",
+    "webpack": "5.102.0"
   }
 }

--- a/src/bbcode/index.tsx
+++ b/src/bbcode/index.tsx
@@ -1,0 +1,52 @@
+import classNames from 'classnames';
+import React from 'react';
+import BBText from '../bbtext';
+import styles from './styles.module.scss';
+import type { IPropsBBBase, TBBTextSize, TBBTextColor } from '../types';
+
+// Monospace stack with a CSS-variable hook so consumers can override the font
+const FONT_FAMILY_MONO =
+  "var(--font-family-mono, 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace)";
+
+/**
+ * PROPS
+ *
+ * @param {React.ReactNode} children - The code / command to display
+ * @param {TBBTextSize=} size - the size of the code text (reuses the BBText scale)
+ * @param {TBBTextColor=} color - the color of the code text (reuses the BBText scale)
+ * @param {boolean=} block - render as a block (<pre><code>) instead of inline (<code>)
+ * @param {string=} className - Any class name to add
+ */
+export interface IPropsBBCode extends IPropsBBBase {
+  children: React.ReactNode;
+  size?: TBBTextSize;
+  color?: TBBTextColor;
+  block?: boolean;
+}
+
+/**
+ * BBCode
+ *
+ * Inline <code> (or block <pre><code> when `block`) for short code / CLI snippets.
+ * Renders the monospace + chrome itself and reuses BBText's size/color tokens for the text.
+ * For multi-line terminal mockups with their own syntax highlighting, use raw markup instead.
+ */
+export default function BBCode(Props: IPropsBBCode): React.ReactElement {
+  const { children, size = 'small', color, block = false, className } = Props;
+
+  const inner = (
+    <BBText asSpan size={size} color={color} fontFamily={FONT_FAMILY_MONO}>
+      {children}
+    </BBText>
+  );
+
+  if (block) {
+    return (
+      <pre className={classNames(styles.pre, className)}>
+        <code className={styles.codeBlock}>{inner}</code>
+      </pre>
+    );
+  }
+
+  return <code className={classNames(styles.code, className)}>{inner}</code>;
+}

--- a/src/bbcode/styles.module.scss
+++ b/src/bbcode/styles.module.scss
@@ -1,0 +1,28 @@
+/*
+ * BBCode
+ *
+ * Neutral, theme-agnostic chrome: a translucent grey overlay reads correctly on both
+ * light and dark backgrounds without depending on theme variables. The text color comes
+ * from BBText (via the `color` prop / --text-color-default), so it flips with the theme.
+ */
+
+.code {
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+  background-color: rgba(128, 128, 128, 0.12);
+  border: 1px solid rgba(128, 128, 128, 0.25);
+  white-space: nowrap;
+}
+
+.pre {
+  margin: 0;
+  padding: 1rem;
+  border-radius: 6px;
+  overflow-x: auto;
+  background-color: rgba(128, 128, 128, 0.15);
+  border: 1px solid rgba(128, 128, 128, 0.25);
+}
+
+.codeBlock {
+  white-space: pre;
+}

--- a/src/bblabel/index.tsx
+++ b/src/bblabel/index.tsx
@@ -1,0 +1,46 @@
+import classNames from 'classnames';
+import React from 'react';
+import BBText from '../bbtext';
+import styles from './styles.module.scss';
+import type { TBBTextSize, TBBTextColor } from '../types';
+
+// Mono stack with a CSS-variable hook so consumers can override the font
+const FONT_FAMILY_MONO = "var(--font-family-mono, monospace)";
+
+/**
+ * PROPS
+ *
+ * @param {React.ReactNode} children - The label text
+ * @param {TBBTextSize=} size - the size of the label (default 'tiny')
+ * @param {TBBTextColor=} color - an explicit color; omit for the default muted label ink
+ * @param {string=} className - Any class name to add
+ */
+export interface IPropsBBLabel {
+  children: React.ReactNode;
+  size?: TBBTextSize;
+  color?: TBBTextColor;
+  className?: string;
+}
+
+/**
+ * BBLabel
+ *
+ * Small uppercase, letter-spaced monospace eyebrow / kicker label. Composes BBText for
+ * size / weight / color and adds the mono-label treatment. Renders as a <span>.
+ */
+export default function BBLabel(Props: IPropsBBLabel): React.ReactElement {
+  const { children, size = 'tiny', color, className } = Props;
+
+  return (
+    <BBText
+      asSpan
+      size={size}
+      weight="medium"
+      color={color}
+      fontFamily={FONT_FAMILY_MONO}
+      className={classNames(styles.label, !color && styles.muted, className)}
+    >
+      {children}
+    </BBText>
+  );
+}

--- a/src/bblabel/styles.module.scss
+++ b/src/bblabel/styles.module.scss
@@ -1,0 +1,17 @@
+/*
+ * BBLabel
+ *
+ * The mono eyebrow treatment. Font family (mono) and weight come through BBText props;
+ * size comes from BBText. The muted ink applies only when no explicit color is set, and
+ * relies on import order (BBText imported before these styles) to win over BBText's
+ * default color.
+ */
+
+.label {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.muted {
+  color: var(--mono-label-color, var(--text-color-default, #000));
+}

--- a/src/bbquote/index.tsx
+++ b/src/bbquote/index.tsx
@@ -1,0 +1,62 @@
+import classNames from 'classnames';
+import React from 'react';
+import BBText from '../bbtext';
+import styles from './styles.module.scss';
+import type { IPropsBBBase, TBBTextSize, TBBTextColor } from '../types';
+
+/**
+ * PROPS
+ *
+ * @param {React.ReactNode} children - The quote body
+ * @param {React.ReactNode=} cite - The attribution (name / role); rendered in a <figcaption><cite>
+ * @param {TBBTextSize=} size - the size of the quote body (default 'large')
+ * @param {TBBTextColor=} color - the color of the quote body
+ * @param {TBBTextColor=} citeColor - the color of the attribution
+ * @param {boolean=} italics - whether the quote body is italic
+ * @param {string=} className - Any class name to add to the <figure>
+ */
+export interface IPropsBBQuote extends IPropsBBBase {
+  children: React.ReactNode;
+  cite?: React.ReactNode;
+  size?: TBBTextSize;
+  color?: TBBTextColor;
+  citeColor?: TBBTextColor;
+  italics?: boolean;
+}
+
+/**
+ * BBQuote
+ *
+ * Semantic pull quote: <figure> + <blockquote> with an optional <figcaption><cite> attribution.
+ * The quote body and attribution use BBText so typography and theming stay consistent.
+ */
+export default function BBQuote(Props: IPropsBBQuote): React.ReactElement {
+  const {
+    children,
+    cite,
+    size = 'large',
+    color,
+    citeColor = 'grey_dark',
+    italics = false,
+    className,
+  } = Props;
+
+  return (
+    <figure className={classNames(styles.figure, className)}>
+      <blockquote className={styles.blockquote}>
+        <BBText size={size} color={color} italics={italics}>
+          {children}
+        </BBText>
+      </blockquote>
+      {cite && (
+        <figcaption className={styles.figcaption}>
+          <cite className={styles.cite}>
+            <BBText asSpan size="small" color={citeColor}>
+              {cite}
+            </BBText>
+          </cite>
+        </figcaption>
+      )}
+    </figure>
+  );
+}

--- a/src/bbquote/styles.module.scss
+++ b/src/bbquote/styles.module.scss
@@ -1,0 +1,25 @@
+/*
+ * BBQuote
+ *
+ * Accent left-border pull quote. Text colors come from BBText (theme-aware); the accent
+ * border uses the brand accent variable with a sensible fallback.
+ */
+
+.figure {
+  margin: 0;
+  padding-left: 1rem;
+  border-left: 3px solid var(--accent-color, #f1c500);
+}
+
+.blockquote {
+  margin: 0;
+}
+
+.figcaption {
+  margin-top: 0.5rem;
+}
+
+/* <cite> is italic by default in browsers; keep the attribution upright */
+.cite {
+  font-style: normal;
+}

--- a/src/bbtext/index.tsx
+++ b/src/bbtext/index.tsx
@@ -2,12 +2,13 @@ import classNames from 'classnames';
 import React from 'react';
 import { createClassHelper } from '../utils/scss-class-functions';
 import styles from './styles.module.scss';
-import type { TBBTextSize, TBBTextColor } from '../types';
+import type { TBBTextSize, TBBTextColor, TBBTextWeight } from '../types';
 
 // Create class helper with standardized patterns
 const classHelper = createClassHelper(styles, {
   color: {},  // Direct mapping for most colors
   size: {},   // Direct mapping for sizes
+  weight: { prefix: 'weight_' },  // weight_light, weight_medium, etc.
 });
 
 /**
@@ -16,7 +17,8 @@ const classHelper = createClassHelper(styles, {
  * @param {React.ReactNode} children - The text to display
  * @param {TBBTextSize=} size - the size of text
  * @param {TBBTextColor=} color - the color of the text
- * @param {boolean=} bold - whether the text is bold
+ * @param {boolean=} bold - whether the text is bold (shorthand for weight="bold")
+ * @param {TBBTextWeight=} weight - the font weight; takes precedence over bold when set
  * @param {boolean=} italics - whether the text is italic
  * @param {boolean=} underline - whether the text is underlined
  * @param {boolean=} hover - Whether the text has a hover effect
@@ -30,6 +32,7 @@ export interface IPropsBBText {
   size?: TBBTextSize;
   color?: TBBTextColor;
   bold?: boolean;
+  weight?: TBBTextWeight;
   italics?: boolean;
   underline?: boolean;
   hover?: boolean;
@@ -48,6 +51,7 @@ export default function BBText(Props: IPropsBBText): React.ReactElement {
     size = 'medium',
     color,
     bold = false,
+    weight,
     italics = false,
     underline = false,
     hover = false,
@@ -63,6 +67,13 @@ export default function BBText(Props: IPropsBBText): React.ReactElement {
 
   const getClassSize = (): string => {
     return classHelper.size(size) || '';
+  };
+
+  // weight takes precedence; fall back to the bold shorthand when weight is unset
+  const getClassWeight = (): string => {
+    if (weight) return classHelper.weight(weight) || '';
+    if (bold) return styles.bold;
+    return '';
   };
 
   const getHtmlTag = (): string => {
@@ -101,7 +112,7 @@ export default function BBText(Props: IPropsBBText): React.ReactElement {
         styles.base,
         getClassColor(),
         getClassSize(),
-        bold && styles.bold,
+        getClassWeight(),
         italics && styles.italics,
         underline && styles.underline,
         hover && styles.hover

--- a/src/bbtext/styles.module.scss
+++ b/src/bbtext/styles.module.scss
@@ -21,6 +21,29 @@ $text-size-xxxl: var(--text-size-xxxl, 3.2rem);
   font-weight: 700;
 }
 
+/*
+  * FONT WEIGHTS
+  */
+.weight_light {
+  font-weight: 300;
+}
+
+.weight_regular {
+  font-weight: 400;
+}
+
+.weight_medium {
+  font-weight: 500;
+}
+
+.weight_semibold {
+  font-weight: 600;
+}
+
+.weight_bold {
+  font-weight: 700;
+}
+
 .italics {
   font-style: italic;
 }
@@ -264,7 +287,7 @@ $text-size-xxxl: var(--text-size-xxxl, 3.2rem);
 }
 
 .xxxlarge {
-  font-size: $text-size-xxl;
+  font-size: $text-size-xxxl;
   font-family: $font-family-header;
   margin: 1.2rem 0.2rem;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -203,6 +203,7 @@ export type TBBTextColor =
   | 'warning'
   | 'danger'
   | 'info';
+export type TBBTextWeight = 'light' | 'regular' | 'medium' | 'semibold' | 'bold';
 
 /**
  * FORM TYPES


### PR DESCRIPTION
## Summary
Adds three new components and a `weight` prop to `BBText`, surfaced while converting the Preon marketing site to Base Blocks throughout.

### New components (each composes BBText, reusing its size/color tokens)
- **BBCode** — inline `<code>` / block `<pre><code>` for CLI + code snippets (monospace + neutral theme-agnostic chrome)
- **BBQuote** — semantic `<figure>`/`<blockquote>` pull quote with an optional `<figcaption><cite>` attribution
- **BBLabel** — small uppercase, letter-spaced monospace eyebrow / kicker label (muted ink by default, overridable via `color`)

### BBText
- new `weight` prop: `light` | `regular` | `medium` | `semibold` | `bold`. The existing `bold` boolean stays as a shorthand and is overridden by `weight` when both are set. **Non-breaking.**
- fix: desktop `xxxlarge` now maps to `$text-size-xxxl` (was `$text-size-xxl`, i.e. the same size as `xxlarge`). Mobile was already correct.

### Tests / docs
- Cypress component specs for BBCode / BBQuote / BBLabel + new BBText weight specs
- README + TODO entries

### Validation
Full component suite green locally: **344/344 passing across all 18 specs**. No breaking changes to existing components.